### PR TITLE
Some fixes for template string

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -3812,10 +3812,10 @@ remove_all_quote_escaping(char_u *expr, int is_literal_string)
 	if (is_escaped_quote(is_literal_string, p))
 	{
 	    ga_append(&result, *(p + 1));
-	    MB_PTR_ADV(p);
+	    ++p;
 	    continue;
 	}
-	ga_append(&result, *p);
+	ga_concatn(&result, p, mb_ptr2len(p));
     }
 
     return (char_u *) result.ga_data;
@@ -3841,7 +3841,7 @@ escape_quotes_in_quote(char_u *x, int is_literal_string)
 	    ga_concat(&result, (char_u *) "\\\"");
 	    continue;
 	}
-	ga_append(&result, *p);
+	ga_concatn(&result, p, mb_ptr2len(p));
     }
 
     return (char_u *) result.ga_data;

--- a/src/eval.c
+++ b/src/eval.c
@@ -59,8 +59,8 @@ static int eval7(char_u **arg, typval_T *rettv, int evaluate, int want_string);
 static int eval7_leader(typval_T *rettv, char_u *start_leader, char_u **end_leaderp);
 
 static int get_template_string_tv(char_u **arg, typval_T *rettv, int evaluate);
-static int read_template_expr(garray_T *result, char_u **expr, int is_literal_string);
-static int read_template_var(garray_T *result, char_u **expr);
+static int read_template_expr(garray_T *result, char_u **expr, int is_literal_string, int evaluate);
+static int read_template_var(garray_T *result, char_u **expr, int is_literal_string, int evaluate);
 static int is_escaped_quote(int is_literal_string, char_u *quotes);
 static int free_unref_items(int copyID);
 static char_u *make_expanded_name(char_u *in_start, char_u *expr_start, char_u *expr_end, char_u *in_end);
@@ -2623,7 +2623,7 @@ eval7(
 		break;
 
     /*
-     * Template string constant: $"${var}", $'${val}'.
+     * Template string constant: $"${expr}", $'${expr}'.
      * or
      * Environment variable: $VAR.
      */
@@ -3693,7 +3693,7 @@ is_closing_quote(
 }
 
 /*
- * Allocate a variable for $"${var}" and $'${val}' constant.
+ * Allocate a variable for $"${expr}" and $'${expr}' constant.
  * Return OK or FAIL.
  */
     static int
@@ -3730,8 +3730,8 @@ get_template_string_tv(char_u **arg, typval_T *rettv, int evaluate)
 	    // forward to beginning of the template literal
 	    *arg += does_expect_embraced ? 2 : 1;
 	    success = does_expect_embraced
-		? read_template_expr(&result, arg, is_literal_string)
-		: read_template_var(&result, arg);
+		? read_template_expr(&result, arg, is_literal_string, evaluate)
+		: read_template_var(&result, arg, is_literal_string, evaluate);
 	    if (!success)
 	    {
 		ga_clear(&result);
@@ -3759,7 +3759,11 @@ get_template_string_tv(char_u **arg, typval_T *rettv, int evaluate)
     else
     {
 	char_u	*to_free = (char_u *) result.ga_data;
-	int	success = eval1((char_u**) &result.ga_data, rettv, TRUE);
+	int	success;
+
+	success = is_literal_string ?
+	    get_lit_string_tv((char_u**) &result.ga_data, rettv, TRUE) :
+	    get_string_tv((char_u**) &result.ga_data, rettv, TRUE);
 
 	vim_free(to_free);
 	return success;
@@ -3852,7 +3856,11 @@ escape_quotes_in_quote(char_u *x, int is_literal_string)
  * Returns OK when succeed, or returns FAIL.
  */
     static int
-read_template_expr(garray_T *result, char_u **expr, int is_literal_string)
+read_template_expr(
+	garray_T *result,
+	char_u **expr,
+	int is_literal_string,
+	int evaluate)
 {
     char_u	    *expr_head = *expr;
     size_t	    nested_blocks = 0;
@@ -3889,6 +3897,9 @@ read_template_expr(garray_T *result, char_u **expr, int is_literal_string)
 	return FAIL;
     }
 
+    if (!evaluate)
+	return OK;
+
     /*
      * Evaluate the expr
      */
@@ -3918,7 +3929,7 @@ read_template_expr(garray_T *result, char_u **expr, int is_literal_string)
 	if (!success)
 	    return FAIL;
 
-	// Evaluate the lambda call
+	// Escape quotes in the result
 	escaped = escape_quotes_in_quote(var_value.vval.v_string,
 							is_literal_string);
 	ga_concat(result, escaped);
@@ -3933,7 +3944,11 @@ read_template_expr(garray_T *result, char_u **expr, int is_literal_string)
  * Returns OK when succeed, or returns FALSE.
  */
     static int
-read_template_var(garray_T *result, char_u **expr)
+read_template_var(
+	garray_T *result,
+	char_u **expr,
+	int is_literal_string,
+	int evaluate)
 {
     char_u *expr_head = *expr;
 
@@ -3953,6 +3968,12 @@ read_template_var(garray_T *result, char_u **expr)
 	}
     }
 
+    if (!evaluate)
+    {
+	--*expr;
+	return OK;
+    }
+
     /*
      * Evaluate the variable
      */
@@ -3964,6 +3985,7 @@ read_template_var(garray_T *result, char_u **expr)
 	char_u		*to_free_stringified;
 	typval_T	var_value = { VAR_UNKNOWN, VAR_LOCKED, { 0 } };
 	char_u		last = **expr;  // to recover
+	char_u		*escaped;
 
 	// Get a lambda call of STRINGIFY and the var
 	**expr = NUL;
@@ -3981,9 +4003,15 @@ read_template_var(garray_T *result, char_u **expr)
 	    return FAIL;
 	}
 
-	ga_concat(result, var_value.vval.v_string);
+	// Escape quotes in the result
+	escaped = escape_quotes_in_quote(var_value.vval.v_string,
+							is_literal_string);
+	ga_concat(result, escaped);
 	vim_free(var_value.vval.v_string);
-	--*expr;  // To be forwarded by for's continue, look up a last character of the identifier
+	vim_free(escaped);
+	// To be forwarded by for's continue, look up a last character of the
+	// identifier
+	--*expr;
     }
 
     return OK;

--- a/src/eval.c
+++ b/src/eval.c
@@ -3846,6 +3846,11 @@ escape_quotes_in_quote(char_u *x, int is_literal_string)
 	    ga_concat(&result, (char_u *) "\\\"");
 	    continue;
 	}
+	else if (!is_literal_string && *p == '\\')
+	{
+	    ga_concat(&result, (char_u *) "\\\\");
+	    continue;
+	}
 	ga_concatn(&result, p, mb_ptr2len(p));
     }
 

--- a/src/eval.c
+++ b/src/eval.c
@@ -2628,13 +2628,9 @@ eval7(
      * Environment variable: $VAR.
      */
     case '$':	if (*(*arg + 1) == '"' || *(*arg + 1) == '\'')
-		{
 		    ret = get_template_string_tv(arg, rettv, evaluate);
-		}
 		else
-		{
 		    ret = get_env_tv(arg, rettv, evaluate);
-		}
 		break;
 
     /*
@@ -3679,7 +3675,10 @@ get_lit_string_tv(char_u **arg, typval_T *rettv, int evaluate)
 }
 
     static int
-is_closing_quote(char_u *template, int is_literal_string, int *is_skipping_needed)
+is_closing_quote(
+	char_u *template,
+	int is_literal_string,
+	int *is_skipping_needed)
 {
     char_u quote = is_literal_string ? '\'' : '"';
 
@@ -3712,7 +3711,9 @@ get_template_string_tv(char_u **arg, typval_T *rettv, int evaluate)
     ga_append(&result, quote);
 
     // Continue while it is not NULL and it is not a closing quote.
-    for (; (**arg != NUL) && !is_closing_quote(*arg, is_literal_string, &is_skipping_needed); ++*arg)
+    for (; (**arg != NUL) &&
+	    !is_closing_quote(*arg, is_literal_string, &is_skipping_needed);
+	    ++*arg)
     {
 	if (is_skipping_needed)
 	{
@@ -3726,7 +3727,8 @@ get_template_string_tv(char_u **arg, typval_T *rettv, int evaluate)
 	    int success;
 	    int does_expect_embraced = *(*arg + 1) == '{';
 
-	    *arg += does_expect_embraced ? 2 : 1;  // forward to beginning of the template literal
+	    // forward to beginning of the template literal
+	    *arg += does_expect_embraced ? 2 : 1;
 	    success = does_expect_embraced
 		? read_template_expr(&result, arg, is_literal_string)
 		: read_template_var(&result, arg);
@@ -3784,9 +3786,7 @@ did_encount_string_quote(char_u **expr, int is_literal_string)
 	did_encount_escaped_quote;
 
     if (did_encount_escaped_quote)
-    {
 	++*expr;
-    }
 
     return result;
 }
@@ -3831,10 +3831,12 @@ escape_quotes_in_quote(char_u *x, int is_literal_string)
 
     for (p = x; *p != NUL; MB_PTR_ADV(p))
     {
-	if (is_literal_string && *p == '\'') {
+	if (is_literal_string && *p == '\'')
+	{
 	    ga_concat(&result, (char_u *) "''");
 	    continue;
-	} else if (!is_literal_string && *p == '"')
+	}
+	else if (!is_literal_string && *p == '"')
 	{
 	    ga_concat(&result, (char_u *) "\\\"");
 	    continue;
@@ -3855,31 +3857,27 @@ read_template_expr(garray_T *result, char_u **expr, int is_literal_string)
     size_t	    nested_blocks = 0;
     int		    is_in_quote = FALSE;
 
-    // While the closing '}' encounted. The '}' is neither '}' of a dict nor '}' in a string.
-    for (; !(!is_in_quote && **expr == '}' && nested_blocks == 0); MB_PTR_ADV(*expr))
+    // While the closing '}' encounted. The '}' is neither '}' of a dict nor
+    // '}' in a string.
+    for (; !(!is_in_quote && **expr == '}' && nested_blocks == 0);
+							MB_PTR_ADV(*expr))
     {
 	switch (**expr)
 	{
 	    case '{':
 		if (!is_in_quote)
-		{
 		    ++nested_blocks;
-		}
 		break;
 	    case '}':
 		if (!is_in_quote)
-		{
 		    --nested_blocks;
-		}
 		break;
 	    case NUL:
 		semsg(_("E451: Unterminated template literal: %s"), expr_head);
 		return FAIL;
 	    default:
 		if (did_encount_string_quote(expr, is_literal_string))
-		{
 		    is_in_quote = !is_in_quote;
-		}
 		break;
 	}
     }
@@ -3917,12 +3915,11 @@ read_template_expr(garray_T *result, char_u **expr, int is_literal_string)
 	success = eval1(&stringified, &var_value, TRUE);
 	vim_free(to_free_stringified);
 	if (!success)
-	{
 	    return FAIL;
-	}
 
 	// Evaluate the lambda call
-	escaped = escape_quotes_in_quote(var_value.vval.v_string, is_literal_string);
+	escaped = escape_quotes_in_quote(var_value.vval.v_string,
+							is_literal_string);
 	ga_concat(result, escaped);
 	vim_free(var_value.vval.v_string);
 	vim_free(escaped);

--- a/src/eval.c
+++ b/src/eval.c
@@ -3767,25 +3767,26 @@ get_template_string_tv(char_u **arg, typval_T *rettv, int evaluate)
 }
 
     static int
-did_encount_string_quote(char_u **expr, int is_literal_string)
+did_encounter_string_quote(char_u **expr, int is_literal_string)
 {
-    // encounted a double quote in the single quoted string (lit str),
-    int did_encount_double_in_single =
+    // encountered a double quote in the single quoted string (lit str),
+    int did_encounter_double_in_single =
 	(is_literal_string && **expr == '"');
 
     // a single quote in the double quoted string,
-    int did_encount_single_in_double =
+    int did_encounter_single_in_double =
 	(!is_literal_string && **expr == '\'');
 
     // or a single quote in the double quoted string?
-    int did_encount_escaped_quote = is_escaped_quote(is_literal_string, *expr);
+    int did_encounter_escaped_quote =
+				is_escaped_quote(is_literal_string, *expr);
 
     int result =
-	did_encount_double_in_single ||
-	did_encount_single_in_double ||
-	did_encount_escaped_quote;
+	did_encounter_double_in_single ||
+	did_encounter_single_in_double ||
+	did_encounter_escaped_quote;
 
-    if (did_encount_escaped_quote)
+    if (did_encounter_escaped_quote)
 	++*expr;
 
     return result;
@@ -3857,7 +3858,7 @@ read_template_expr(garray_T *result, char_u **expr, int is_literal_string)
     size_t	    nested_blocks = 0;
     int		    is_in_quote = FALSE;
 
-    // While the closing '}' encounted. The '}' is neither '}' of a dict nor
+    // While the closing '}' encountered. The '}' is neither '}' of a dict nor
     // '}' in a string.
     for (; !(!is_in_quote && **expr == '}' && nested_blocks == 0);
 							MB_PTR_ADV(*expr))
@@ -3876,7 +3877,7 @@ read_template_expr(garray_T *result, char_u **expr, int is_literal_string)
 		semsg(_("E451: Unterminated template literal: %s"), expr_head);
 		return FAIL;
 	    default:
-		if (did_encount_string_quote(expr, is_literal_string))
+		if (did_encounter_string_quote(expr, is_literal_string))
 		    is_in_quote = !is_in_quote;
 		break;
 	}

--- a/src/misc2.c
+++ b/src/misc2.c
@@ -2143,11 +2143,19 @@ ga_add_string(garray_T *gap, char_u *p)
     void
 ga_concat(garray_T *gap, char_u *s)
 {
-    int    len;
-
     if (s == NULL || *s == NUL)
 	return;
-    len = (int)STRLEN(s);
+    ga_concatn(gap, s, (int)STRLEN(s));
+}
+
+/*
+ * Similar to ga_concat(), but concatenate only specified length.
+ */
+    void
+ga_concatn(garray_T *gap, char_u *s, int len)
+{
+    if (s == NULL || len <= 0)
+	return;
     if (ga_grow(gap, len) == OK)
     {
 	mch_memmove((char *)gap->ga_data + gap->ga_len, s, (size_t)len);

--- a/src/proto/misc2.pro
+++ b/src/proto/misc2.pro
@@ -62,6 +62,7 @@ int ga_grow(garray_T *gap, int n);
 char_u *ga_concat_strings(garray_T *gap, char *sep);
 void ga_add_string(garray_T *gap, char_u *p);
 void ga_concat(garray_T *gap, char_u *s);
+void ga_concatn(garray_T *gap, char_u *s, int len);
 void ga_append(garray_T *gap, int c);
 void append_ga_line(garray_T *gap);
 int simplify_key(int key, int *modifiers);

--- a/src/testdir/test_alot.vim
+++ b/src/testdir/test_alot.vim
@@ -32,6 +32,5 @@ source test_sha256.vim
 source test_tabline.vim
 source test_tagcase.vim
 source test_tagfunc.vim
-source test_template_string.vim
 source test_unlet.vim
 source test_wnext.vim

--- a/src/testdir/test_template_string.vim
+++ b/src/testdir/test_template_string.vim
@@ -30,6 +30,8 @@ func Test_template_string_basic()
   call assert_equal("'", $'$x')
   let x = '"'
   call assert_equal('"', $"$x")
+  let x = '\x31'
+  call assert_equal('\x31', $"$x")
   let x20 = 20
   call assert_equal('20', $'$x20')
   let Fo_O0O = 30

--- a/src/testdir/test_template_string.vim
+++ b/src/testdir/test_template_string.vim
@@ -23,9 +23,13 @@ func Test_template_string_basic()
   " Variables
   let x = 10
   call assert_equal('I have 10', $'I have ${x}')
-  "" Only variables can be ommt "{}"
+  "" Only variables can be omit "{}"
   call assert_equal('I have 10', $'I have $x')
   call assert_equal('10 and me', $'$x and me')
+  let x = "'"
+  call assert_equal("'", $'$x')
+  let x = '"'
+  call assert_equal('"', $"$x")
   let x20 = 20
   call assert_equal('20', $'$x20')
   let Fo_O0O = 30
@@ -73,6 +77,7 @@ func Test_template_string_appendix()
 
   " Multi byte string
   call assert_equal('こんにちは Vim', $'こんにちは ${"Vim"}')
+  call assert_equal('あ', $'${"あ"}')
 endfunc
 
 " These should be an exception, should not be a 'Segmentation fault'.


### PR DESCRIPTION
* Fix coding style
  * 80 columns.
  * Don't use { } if not needed.
* Fix multibyte handling
  * `$'${"あ"}'` causes error.
* Fix misspelling
  * "encount" is a mistake of "encounter".
* Fix some issues
  * Stop using eval1() in get_template_string_tv().
  * Don't evaluate the string if "evaluate" is 0.
  * Fix `let x = '"' | echo $"$x"`.